### PR TITLE
Improved usability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,9 +81,13 @@ celerybeat-schedule
 # virtualenv
 venv/
 ENV/
+.venv
 
 # Spyder project settings
 .spyderproject
 
 # Rope project settings
 .ropeproject
+
+# Visual Studio Code
+.vscode

--- a/py_inspect.py
+++ b/py_inspect.py
@@ -1,31 +1,54 @@
+from PyQt5.QtCore import QLocale
+from PyQt5.QtCore import QCoreApplication
+from PyQt5.QtCore import QSettings
+from PyQt5.QtCore import Qt
+from PyQt5.QtCore import QAbstractTableModel
+from PyQt5.QtCore import QVariant
+from PyQt5.QtGui import QStandardItemModel
+from PyQt5.QtGui import QStandardItem
+from PyQt5.QtWidgets import QApplication
+from PyQt5.QtWidgets import QWidget
+from PyQt5.QtWidgets import QGridLayout
+from PyQt5.QtWidgets import QLabel
+from PyQt5.QtWidgets import QComboBox
+from PyQt5.QtWidgets import QTreeView
+from PyQt5.QtWidgets import QTableView
 import sys
+import warnings
 
+warnings.simplefilter("ignore", UserWarning)
+sys.coinit_flags = 2
 from pywinauto import backend
-
-from PyQt5.QtCore import *
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import *
 
 
 def main():
     app = QApplication(sys.argv)
+    app.setStyle('Fusion')
+
     w = MyWindow()
     w.show()
     sys.exit(app.exec_())
 
 
 class MyWindow(QWidget):
-    def __init__(self, *args):
-        QWidget.__init__(self, *args)
+    def __init__(self):
+        super(MyWindow, self).__init__()
 
-        self.setFixedSize(930, 631)
+        self.setMinimumSize(1000, 1000)
         self.setLocale(QLocale(QLocale.English, QLocale.UnitedStates))
-        self.setWindowTitle(QCoreApplication.translate("MainWindow", "PyInspect"))
+        self.setWindowTitle(
+            QCoreApplication.translate("MainWindow", "PyInspect"))
 
-        self.central_widget = QWidget(self)
+        self.settings = QSettings('py_inspect', 'MainWindow')
 
-        self.comboBox = QComboBox(self.central_widget)
-        self.comboBox.setGeometry(QRect(10, 10, 451, 22))
+        # Main layout
+        self.mainLayout = QGridLayout()
+
+        # Backend label
+        self.backendLabel = QLabel("Backend Type")
+
+        # Backend combobox
+        self.comboBox = QComboBox()
         self.comboBox.setMouseTracking(False)
         self.comboBox.setMaxVisibleItems(5)
         self.comboBox.setObjectName("comboBox")
@@ -33,20 +56,31 @@ class MyWindow(QWidget):
         for _backend in backend.registry.backends.keys():
             self.comboBox.addItem(_backend)
 
-        self.tree_view = QTreeView(self.central_widget)
-        self.tree_view.setGeometry(QRect(10, 40, 451, 581))
+        # Add top widgets to main window
+        self.mainLayout.addWidget(self.backendLabel, 0, 0, 1, 1)
+        self.mainLayout.addWidget(self.comboBox, 0, 1, 1, 1)
+
+        self.tree_view = QTreeView()
         self.tree_view.setColumnWidth(0, 150)
 
         self.comboBox.setCurrentText('uia')
         self.__initialize_calc()
 
-        self.table_view = QTableView(self.central_widget)
-        self.table_view.setGeometry(QRect(470, 40, 451, 581))
+        self.table_view = QTableView()
 
         self.comboBox.activated[str].connect(self.__show_tree)
 
+        # Add center widgets to main window
+        self.mainLayout.addWidget(self.tree_view, 1, 0, 1, 1)
+        self.mainLayout.addWidget(self.table_view, 1, 1, 1, 1)
+
+        self.setLayout(self.mainLayout)
+        geometry = self.settings.value('Geometry', bytes('', 'utf-8'))
+        self.restoreGeometry(geometry)
+
     def __initialize_calc(self, _backend='uia'):
-        self.element_info = backend.registry.backends[_backend].element_info_class()
+        self.element_info \
+            = backend.registry.backends[_backend].element_info_class()
         self.tree_model = MyTreeModel(self.element_info, _backend)
         self.tree_model.setHeaderData(0, Qt.Horizontal, 'Controls')
         self.tree_view.setModel(self.tree_model)
@@ -58,10 +92,16 @@ class MyWindow(QWidget):
 
     def __show_property(self, index=None):
         data = index.data()
-        self.table_model = MyTableModel(self.tree_model.props_dict.get(data), self)
+        self.table_model \
+            = MyTableModel(self.tree_model.props_dict.get(data), self)
         self.table_view.wordWrap()
         self.table_view.setModel(self.table_model)
         self.table_view.setColumnWidth(1, 320)
+
+    def closeEvent(self, event):
+        geometry = self.saveGeometry()
+        self.settings.setValue('Geometry', geometry)
+        super(MyWindow, self).closeEvent(event)
 
 
 class MyTreeModel(QStandardItemModel):
@@ -79,14 +119,17 @@ class MyTreeModel(QStandardItemModel):
     def __get_next(self, element_info, parent):
         for child in element_info.children():
             self.__generate_props_dict(child)
-            child_item = QStandardItem(self.__node_name(child))
+            child_item \
+                = QStandardItem(self.__node_name(child))
             child_item.setEditable(False)
             parent.appendRow(child_item)
             self.__get_next(child, child_item)
 
     def __node_name(self, element_info):
         if 'uia' == self.backend:
-            return '%s "%s" (%s)' % (str(element_info.control_type), str(element_info.name), id(element_info))
+            return '%s "%s" (%s)' % (str(element_info.control_type),
+                                     str(element_info.name),
+                                     id(element_info))
         return '"%s" (%s)' % (str(element_info.name), id(element_info))
 
     def __generate_props_dict(self, element_info):
@@ -106,6 +149,7 @@ class MyTreeModel(QStandardItemModel):
                       ] if (self.backend == 'win32') else []
 
         props_uia = [
+                        ['automation_id', str(element_info.automation_id)],
                         ['control_type', str(element_info.control_type)],
                         ['element', str(element_info.element)],
                         ['framework_id', str(element_info.framework_id)],


### PR DESCRIPTION
Actual py_inspect version use fixed window size. It's not particularly user-friendly. With Qt GridLayout the user can decide by themself which window size fits the requirements (screen resolution, personal preferences, etc.). After the user closes the window, py_inspect store actual window geometry and restore it again with next application start.

Additional it would be good to extend attribute list, so I started with automation_id.